### PR TITLE
Refactor (src/middleware/headers.js:12): Function with high complexity (count = 34): exports #251

### DIFF
--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -9,108 +9,145 @@ const languages = require('../languages');
 const helpers = require('./helpers');
 const plugins = require('../plugins');
 
-module.exports = function (middleware) {
-	middleware.addHeaders = helpers.try((req, res, next) => {
-		const headers = {
-			'X-Powered-By': encodeURI(meta.config['powered-by'] || 'NodeBB'),
-			'Access-Control-Allow-Methods': encodeURI(meta.config['access-control-allow-methods'] || ''),
-			'Access-Control-Allow-Headers': encodeURI(meta.config['access-control-allow-headers'] || ''),
-		};
+function buildBaseHeaders() {
+	return {
+		'X-Powered-By': encodeURI(meta.config['powered-by'] || 'NodeBB'),
+		'Access-Control-Allow-Methods': encodeURI(meta.config['access-control-allow-methods'] || ''),
+		'Access-Control-Allow-Headers': encodeURI(meta.config['access-control-allow-headers'] || ''),
+	};
+}
 
-		if (meta.config['csp-frame-ancestors']) {
-			headers['Content-Security-Policy'] = `frame-ancestors ${meta.config['csp-frame-ancestors']}`;
-			if (meta.config['csp-frame-ancestors'] === '\'none\'') {
-				headers['X-Frame-Options'] = 'DENY';
-			}
-		} else {
-			headers['Content-Security-Policy'] = 'frame-ancestors \'self\'';
-			headers['X-Frame-Options'] = 'SAMEORIGIN';
+function applyCspHeaders(headers) {
+	if (meta.config['csp-frame-ancestors']) {
+		headers['Content-Security-Policy'] = `frame-ancestors ${meta.config['csp-frame-ancestors']}`;
+		if (meta.config['csp-frame-ancestors'] === '\'none\'') {
+			headers['X-Frame-Options'] = 'DENY';
 		}
+	} else {
+		headers['Content-Security-Policy'] = 'frame-ancestors \'self\'';
+		headers['X-Frame-Options'] = 'SAMEORIGIN';
+	}
+}
 
-		if (meta.config['access-control-allow-origin']) {
-			let origins = meta.config['access-control-allow-origin'].split(',');
-			origins = origins.map(origin => origin && origin.trim());
+function setAllowOrigin(headers, origin) {
+	headers['Access-Control-Allow-Origin'] = encodeURI(origin);
+	headers.Vary = headers.Vary ? `${headers.Vary}, Origin` : 'Origin';
+}
 
-			if (origins.includes(req.get('origin'))) {
-				headers['Access-Control-Allow-Origin'] = encodeURI(req.get('origin'));
-				headers.Vary = headers.Vary ? `${headers.Vary}, Origin` : 'Origin';
-			}
-		}
+function handleCorsAllowOriginList(headers, origin) {
+	if (!meta.config['access-control-allow-origin']) {
+		return;
+	}
+	let origins = meta.config['access-control-allow-origin'].split(',');
+	origins = origins.map(originStr => originStr && originStr.trim());
+	if (origins.includes(origin)) {
+		setAllowOrigin(headers, origin);
+	}
+}
 
-		if (meta.config['access-control-allow-origin-regex']) {
-			let originsRegex = meta.config['access-control-allow-origin-regex'].split(',');
-			originsRegex = originsRegex.map((origin) => {
-				try {
-					origin = new RegExp(origin.trim());
-				} catch (err) {
-					winston.error(`[middleware.addHeaders] Invalid RegExp For access-control-allow-origin ${origin}`);
-					origin = null;
-				}
-				return origin;
-			});
-
-			originsRegex.forEach((regex) => {
-				if (regex && regex.test(req.get('origin'))) {
-					headers['Access-Control-Allow-Origin'] = encodeURI(req.get('origin'));
-					headers.Vary = headers.Vary ? `${headers.Vary}, Origin` : 'Origin';
-				}
-			});
-		}
-
-		if (meta.config['permissions-policy']) {
-			headers['Permissions-Policy'] = meta.config['permissions-policy'];
-		}
-
-		if (meta.config['access-control-allow-credentials']) {
-			headers['Access-Control-Allow-Credentials'] = meta.config['access-control-allow-credentials'];
-		}
-
-		if (process.env.NODE_ENV === 'development') {
-			headers['X-Upstream-Hostname'] = os.hostname().replace(/[^0-9A-Za-z-.]/g, '');
-		}
-
-		for (const [key, value] of Object.entries(headers)) {
-			if (value) {
-				res.setHeader(key, value);
-			}
-		}
-
-		next();
-	});
-
-	middleware.autoLocale = helpers.try(async (req, res, next) => {
-		await plugins.hooks.fire('filter:middleware.autoLocale', {
-			req: req,
-			res: res,
-		});
-		if (req.query.lang) {
-			const langs = await listCodes();
-			if (!langs.includes(req.query.lang)) {
-				req.query.lang = meta.config.defaultLang;
-			}
-			return next();
-		}
-
-		if (meta.config.autoDetectLang && req.uid === 0) {
-			const langs = await listCodes();
-			const lang = req.acceptsLanguages(langs);
-			if (!lang) {
-				return next();
-			}
-			req.query.lang = lang;
-		}
-
-		next();
-	});
-
-	async function listCodes() {
-		const defaultLang = meta.config.defaultLang || 'en-GB';
+function parseOriginRegexList(raw) {
+	return raw.split(',').map((originRx) => {
 		try {
-			const codes = await languages.listCodes();
-			return _.uniq([defaultLang, ...codes]);
+			return new RegExp(originRx.trim());
 		} catch (err) {
-			winston.error(`[middleware/autoLocale] Could not retrieve languages codes list! ${err.stack}`);
-			return [defaultLang];
+			winston.error(`[middleware.addHeaders] Invalid RegExp For access-control-allow-origin ${originRx}`);
+			return null;
+		}
+	});
+}
+
+function handleCorsAllowOriginRegex(headers, origin) {
+	if (!meta.config['access-control-allow-origin-regex']) {
+		return;
+	}
+	const originsRegex = parseOriginRegexList(meta.config['access-control-allow-origin-regex']);
+	if (originsRegex.some(regex => regex && regex.test(origin))) {
+		setAllowOrigin(headers, origin);
+	}
+}
+
+function applyCorsAllowOrigin(headers, req) {
+	const origin = req.get('origin');
+	handleCorsAllowOriginList(headers, origin);
+	handleCorsAllowOriginRegex(headers, origin);
+}
+
+function applyAdditionalHeaders(headers) {
+	if (meta.config['permissions-policy']) {
+		headers['Permissions-Policy'] = meta.config['permissions-policy'];
+	}
+	if (meta.config['access-control-allow-credentials']) {
+		headers['Access-Control-Allow-Credentials'] = meta.config['access-control-allow-credentials'];
+	}
+	if (process.env.NODE_ENV === 'development') {
+		headers['X-Upstream-Hostname'] = os.hostname().replace(/[^0-9A-Za-z-.]/g, '');
+	}
+}
+
+function writeHeaders(res, headers) {
+	for (const [key, value] of Object.entries(headers)) {
+		if (value) {
+			res.setHeader(key, value);
 		}
 	}
+}
+
+const addHeadersHandler = helpers.try((req, res, next) => {
+	const headers = buildBaseHeaders();
+	applyCspHeaders(headers);
+	applyCorsAllowOrigin(headers, req);
+	applyAdditionalHeaders(headers);
+	writeHeaders(res, headers);
+	next();
+});
+
+async function listCodes() {
+	const defaultLang = meta.config.defaultLang || 'en-GB';
+	try {
+		const codes = await languages.listCodes();
+		return _.uniq([defaultLang, ...codes]);
+	} catch (err) {
+		winston.error(`[middleware/autoLocale] Could not retrieve languages codes list! ${err.stack}`);
+		return [defaultLang];
+	}
+}
+
+async function handleLangQuery(req) {
+	if (!req.query.lang) {
+		return false;
+	}
+	const langs = await listCodes();
+	if (!langs.includes(req.query.lang)) {
+		req.query.lang = meta.config.defaultLang;
+	}
+	return true;
+}
+
+async function maybeDetectAnonLang(req) {
+	if (!meta.config.autoDetectLang || req.uid !== 0) {
+		return false;
+	}
+	const langs = await listCodes();
+	const lang = req.acceptsLanguages(langs);
+	if (!lang) {
+		return false;
+	}
+	req.query.lang = lang;
+	return true;
+}
+
+const autoLocaleHandler = helpers.try(async (req, res, next) => {
+	await plugins.hooks.fire('filter:middleware.autoLocale', { req: req, res: res });
+	if (await handleLangQuery(req)) {
+		return next();
+	}
+	if (await maybeDetectAnonLang(req)) {
+		return next();
+	}
+	next();
+});
+
+module.exports = function (middleware) {
+	middleware.addHeaders = addHeadersHandler;
+	middleware.autoLocale = autoLocaleHandler;
 };


### PR DESCRIPTION
# P1B: Starter Task: Refactoring PR

## 1. Issue


https://github.com/CMU-313/NodeBB/issues/242

/workspaces/NodeBB/src/middleware/headers.js

**What do you think this file does?**

It sets security/cors headers, adds a devonly header, and auto detects guest language.

**What is the scope of your refactoring within that file?**
Header and locale logic were split into small helpers, inline handlers removed, and exports simplified.

**Which Qlty‑reported issue did you address?**
The main function’s complexity (34) was reduced and now exports are simple with no warnings.

## 2. Refactoring

**How did the specific issue you chose impact the codebase’s adaptability?**

One large function made headers logic hard to read, change, or test.


**What changes did you make to resolve the issue?**

Split logic into small helpers buildBaseHeaders, applyCspHeaders, CORS helpers, applyAdditionalHeaders, writeHeaders. Created addHeadersHandler and autoLocaleHandler. Split locale flow into handleLangQuery and maybeDetectAnonLang. Kept listCodes as a shared helper.

**How do your changes improve adaptability? Did you consider alternatives?**

Easier to change one piece (e.g., CORS) without touching others.


## 3. Validation

**How did you trigger the refactored code path from the UI?**

Accessed NodeBB Through Browser and code path triggered automatically.

**Attach a screenshot of the logs and UI demonstrating the trigger.**
<img width="1140" height="570" alt="Screenshot 2025-09-04 at 10 49 27 PM" src="https://github.com/user-attachments/assets/3d746574-d00f-4065-a3b8-319acfd4c4f1" />


*(Run `./nodebb log`; include the relevant UI view. Temporary logs should be removed before final commit.)*


    ../../../bootstrap/scss/forms/_form-control.scss 40:7  @import
    bootstrap/scss/_forms.scss 3:9                         @import
    - 19:9                                                 root stylesheet

WARNING: The keyword 'none' must be used as a single argument.
    ../../../bootstrap/scss/mixins/_box-shadow.scss 10:9  box-shadow()
    ../../../bootstrap/scss/forms/_form-select.scss 32:7  @import
    bootstrap/scss/_forms.scss 4:9                        @import
    - 19:9                                                root stylesheet


**Attach a screenshot of `qlty smells --no-snippets <full/path/to/file.js>` showing fewer reported issues after the changes.**
<img width="563" height="100" alt="Screenshot 2025-09-04 at 11 05 31 PM" src="https://github.com/user-attachments/assets/fbb280e7-c1f4-4adc-814f-a160126a289a" />
